### PR TITLE
Refac : Styled 태그 이름 수정 및 코드 구조 리팩토링

### DIFF
--- a/src/Avatar/Avatar.js
+++ b/src/Avatar/Avatar.js
@@ -12,6 +12,45 @@ const SIZE = {
   SMALL: "small",
 };
 
+export const Avatar = ({ loading, username, src, size, ...props }) => {
+  let avatarFigure = <UserAlt />;
+  const a11yProps = {};
+
+  if (loading) {
+    a11yProps["aria-busy"] = true;
+    a11yProps["aria-label"] = "Loading avatar ...";
+  } else if (src) {
+    avatarFigure = <img src={src} alt={username} />;
+  } else {
+    a11yProps["aria-label"] = username;
+    avatarFigure = (
+      <Initial size={size} aria-hidden="true">
+        {username.substring(0, 1)}
+      </Initial>
+    );
+  }
+
+  return (
+    <Image size={size} loading={loading} src={src} {...a11yProps} {...props}>
+      {avatarFigure}
+    </Image>
+  );
+};
+
+Avatar.propTypes = {
+  loading: PropTypes.bool,
+  username: PropTypes.string,
+  src: PropTypes.string,
+  size: PropTypes.oneOf(Object.values(SIZE)),
+};
+
+Avatar.defaultProps = {
+  loading: false,
+  username: "김싸페",
+  src: null,
+  size: "large",
+};
+
 const sizeNum = {
   large: 40,
   medium: 28,
@@ -66,42 +105,3 @@ const Initial = styled.div`
   font-size: ${(props) => fontSize[props.size]};
   line-height: ${(props) => sizeNum[props.size]}px;
 `;
-
-export function Avatar({ loading, username, src, size, ...props }) {
-  let avatarFigure = <UserAlt />;
-  const a11yProps = {};
-
-  if (loading) {
-    a11yProps["aria-busy"] = true;
-    a11yProps["aria-label"] = "Loading avatar ...";
-  } else if (src) {
-    avatarFigure = <img src={src} alt={username} />;
-  } else {
-    a11yProps["aria-label"] = username;
-    avatarFigure = (
-      <Initial size={size} aria-hidden="true">
-        {username.substring(0, 1)}
-      </Initial>
-    );
-  }
-
-  return (
-    <Image size={size} loading={loading} src={src} {...a11yProps} {...props}>
-      {avatarFigure}
-    </Image>
-  );
-}
-
-Avatar.propTypes = {
-  loading: PropTypes.bool,
-  username: PropTypes.string,
-  src: PropTypes.string,
-  size: PropTypes.oneOf(Object.values(SIZE)),
-};
-
-Avatar.defaultProps = {
-  loading: false,
-  username: "김싸페",
-  src: null,
-  size: "large",
-};

--- a/src/Avatar/Avatar.stories.js
+++ b/src/Avatar/Avatar.stories.js
@@ -7,58 +7,46 @@ export default {
   component: Avatar,
 };
 
+// TODO : 기본 이미지 소스
+const defaultSrc =
+  "https://user-images.githubusercontent.com/87457066/149450675-18c3f878-2cf9-40cd-884c-1b7db140708b.png";
+
 export const Default = (args) => <Avatar {...args} />;
 
 Default.args = {
   size: "large",
   username: "김싸페",
-
-  // TODO : 기본 이미지 소스
-  src: "https://user-images.githubusercontent.com/87457066/149450675-18c3f878-2cf9-40cd-884c-1b7db140708b.png",
+  src: defaultSrc,
 };
 
-export const Sizes = (args) => (
+export const All = () => (
   <div>
-    <Avatar {...args} size="large" />
-    <Avatar {...args} size="medium" />
-    <Avatar {...args} size="small" />
-  </div>
-);
+    <h1>Sizes</h1>
+    <hr />
+    <div>
+      <h2 style={{ marginBottom: "0.5rem" }}>Images</h2>
+      <Avatar size="large" src={defaultSrc} />
+      <Avatar size="medium" src={defaultSrc} />
+      <Avatar size="small" src={defaultSrc} />
+    </div>
+    <div style={{ marginTop: "1rem" }}>
+      <h2 style={{ marginBottom: "0.5rem" }}>Initials</h2>
+      <Avatar size="large" />
+      <Avatar size="medium" />
+      <Avatar size="small" />
+    </div>
+    <div style={{ marginTop: "1rem" }}>
+      <h2 style={{ marginBottom: "0.5rem" }}>Lodings</h2>
+      <Avatar size="large" loading />
+      <Avatar size="medium" loading />
+      <Avatar size="small" loading />
+    </div>
 
-Sizes.args = {
-  username: "김싸페",
-  src: "https://user-images.githubusercontent.com/87457066/149450675-18c3f878-2cf9-40cd-884c-1b7db140708b.png",
-};
-
-export const Initials = (args) => (
-  <div>
+    <h1 style={{ marginTop: "3rem" }}>Initials</h1>
+    <hr />
     <Avatar username="James" />
     <Avatar username="Mary" />
     <Avatar username="김싸페" />
     <Avatar username="홍길동" />
-  </div>
-);
-
-export const Loading = (args) => (
-  <div>
-    <Avatar {...args} size="large" />
-    <Avatar {...args} size="medium" />
-    <Avatar {...args} size="small" />
-  </div>
-);
-
-Loading.args = {
-  loading: true,
-};
-
-export const Large = (args) => (
-  <div>
-    <Avatar loading size="large" />
-    <Avatar size="large" username="김싸페" />
-    <Avatar
-      size="large"
-      username="김싸페"
-      src="https://user-images.githubusercontent.com/87457066/149450675-18c3f878-2cf9-40cd-884c-1b7db140708b.png"
-    />
   </div>
 );

--- a/src/Avatar/UserAlt.js
+++ b/src/Avatar/UserAlt.js
@@ -1,6 +1,6 @@
 import React from "react";
 
-export function UserAlt({ ...props }) {
+export const UserAlt = ({ ...props }) => {
   return (
     <svg
       width="40"
@@ -33,4 +33,4 @@ export function UserAlt({ ...props }) {
       </defs>
     </svg>
   );
-}
+};

--- a/src/Background/Background.js
+++ b/src/Background/Background.js
@@ -8,13 +8,13 @@ const bgColors = {
   light: color.white,
 };
 
-const StyledBackground = styled.div`
+const Layout = styled.div`
   display: flex;
   padding: 5rem;
   border-radius: 12px;
   background-color: ${(props) => bgColors[props.theme]};
 `;
 
-export function Background({ theme, ...props }) {
-  return <StyledBackground theme={theme} {...props}></StyledBackground>;
+export function Background({ ...props }) {
+  return <Layout {...props} />;
 }

--- a/src/Background/Background.js
+++ b/src/Background/Background.js
@@ -2,6 +2,10 @@ import React from "react";
 import styled from "styled-components";
 import { color } from "../shared/styles";
 
+export const Background = ({ ...props }) => {
+  return <Layout {...props} />;
+};
+
 const bgColors = {
   dark: color.black,
   blue: color.blue100,
@@ -14,7 +18,3 @@ const Layout = styled.div`
   border-radius: 12px;
   background-color: ${(props) => bgColors[props.theme]};
 `;
-
-export function Background({ ...props }) {
-  return <Layout {...props} />;
-}

--- a/src/Comment/CommentInput.js
+++ b/src/Comment/CommentInput.js
@@ -61,7 +61,7 @@ const CharCounter = styled.span`
   color: ${color.gray500};
 `;
 
-const ButtonsBox = styled.div`
+const ButtonBox = styled.div`
   display: flex;
   align-items: center;
   gap: 1rem;
@@ -125,7 +125,7 @@ export function CommentInput({ theme, ...props }) {
       />
       <Footer>
         <CharCounter>{comment.count}/500</CharCounter>
-        <ButtonsBox>
+        <ButtonBox>
           <Icon icon="smile" aria-hidden />
           <Button
             disabled={!comment.value ? "true" : ""}
@@ -134,7 +134,7 @@ export function CommentInput({ theme, ...props }) {
           >
             등록
           </Button>
-        </ButtonsBox>
+        </ButtonBox>
       </Footer>
     </Layout>
   );

--- a/src/Comment/CommentInput.js
+++ b/src/Comment/CommentInput.js
@@ -10,6 +10,65 @@ const THEME = {
   LIGHT: "light",
 };
 
+export const CommentInput = ({ theme, ...props }) => {
+  // 텍스트 입력 시 글자수 카운트 및 버튼 활성화
+  const [comment, setComment] = useState({
+    value: "",
+    count: 0,
+  });
+
+  const onChange = (e) => {
+    setComment({
+      value: e.target.value,
+      count: e.target.value.length,
+    });
+  };
+
+  // 텍스트 입력 시 textarea 세로 사이즈 조정
+  const textareaRef = useRef(null);
+
+  useEffect(() => {
+    const node = textareaRef.current;
+
+    node.style.height = "auto"; // 기본 height 값 초기화 (없을 경우 텍스트 삭제 시 높이 유지)
+    node.style.height = `${node.scrollHeight}px`;
+  }, [comment]);
+
+  return (
+    <Layout theme={theme} {...props}>
+      <Textarea
+        theme={theme}
+        ref={textareaRef}
+        onChange={onChange}
+        value={comment.value}
+        placeholder="댓글로 의견을 나눠보세요 :)"
+        maxLength="500"
+      />
+      <Footer>
+        <CharCounter>{comment.count}/500</CharCounter>
+        <ButtonBox>
+          <Icon icon="smile" aria-hidden />
+          <Button
+            disabled={!comment.value ? "true" : ""}
+            theme={theme}
+            {...props}
+          >
+            등록
+          </Button>
+        </ButtonBox>
+      </Footer>
+    </Layout>
+  );
+};
+
+CommentInput.propTypes = {
+  theme: PropTypes.oneOf(Object.values(THEME)),
+};
+
+CommentInput.defaultProps = {
+  theme: THEME.LIGHT,
+};
+
 const bgColor = {
   dark: color.gray900,
   light: color.gray25,
@@ -37,7 +96,7 @@ const Layout = styled.label`
 const Textarea = styled.textarea`
   width: 100%;
   resize: none;
-
+  overflow: hidden;
   border: none;
   background-color: ${(props) => bgColor[props.theme]};
 
@@ -90,60 +149,3 @@ const Button = styled.button`
     cursor: default;
   }
 `;
-
-export function CommentInput({ theme, ...props }) {
-  const textareaRef = useRef(null);
-
-  const [comment, setComment] = useState({
-    value: "",
-    count: 0,
-  });
-
-  const onChange = (e) => {
-    setComment({
-      value: e.target.value,
-      count: e.target.value.length,
-    });
-  };
-
-  useEffect(() => {
-    const node = textareaRef.current;
-
-    node.style.height = "auto"; // 기본 height 값 초기화 (없을 경우 텍스트 삭제 시 높이 유지)
-    node.style.height = `${node.scrollHeight}px`;
-  }, [comment]);
-
-  return (
-    <Layout theme={theme} {...props}>
-      <Textarea
-        placeholder="댓글로 의견을 나눠보세요 :)"
-        ref={textareaRef}
-        onChange={onChange}
-        maxLength="500"
-        value={comment.value}
-        theme={theme}
-      />
-      <Footer>
-        <CharCounter>{comment.count}/500</CharCounter>
-        <ButtonBox>
-          <Icon icon="smile" aria-hidden />
-          <Button
-            disabled={!comment.value ? "true" : ""}
-            theme={theme}
-            {...props}
-          >
-            등록
-          </Button>
-        </ButtonBox>
-      </Footer>
-    </Layout>
-  );
-}
-
-CommentInput.propTypes = {
-  theme: PropTypes.oneOf(Object.values(THEME)),
-};
-
-CommentInput.defaultProps = {
-  theme: THEME.LIGHT,
-};

--- a/src/Comment/CommentInput.stories.js
+++ b/src/Comment/CommentInput.stories.js
@@ -14,13 +14,13 @@ export const Default = (args) => (
   </Background>
 );
 
-export const All = (args) => (
+export const All = () => (
   <>
     <Background theme="light">
-      <CommentInput theme="light" {...args} />
+      <CommentInput theme="light" />
     </Background>
     <Background theme="dark">
-      <CommentInput theme="dark" {...args} />
+      <CommentInput theme="dark" />
     </Background>
   </>
 );

--- a/src/Icon/Icon.js
+++ b/src/Icon/Icon.js
@@ -3,25 +3,7 @@ import PropTypes from "prop-types";
 import styled from "styled-components";
 import { icons } from "../shared/icons";
 
-const Svg = styled.svg`
-  display: ${(props) => (props.block ? "block" : "inline-block")};
-  vertical-align: middle;
-  shape-rendering: inherit;
-  transform: translate3d(0, 0, 0);
-
-  stroke-width: 2;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-`;
-
-/**
- * An Icon is a piece of visual element, but we must ensure its accessibility while using it.
- * It can have 2 purposes:
- *
- * - *decorative only*: for example, it illustrates a label next to it. We must ensure that it is ignored by screen readers, by setting `aria-hidden` attribute (ex: `<Icon icon="check" aria-hidden />`)
- * - *non-decorative*: it means that it delivers information. For example, an icon as only child in a button. The meaning can be obvious visually, but it must have a proper text alternative via `aria-label` for screen readers. (ex: `<Icon icon="print" aria-label="Print this document" />`)
- */
-export function Icon({ icon, block, ...props }) {
+export const Icon = ({ icon, block, ...props }) => {
   return (
     <Svg
       viewBox="0 0 24 24"
@@ -36,7 +18,7 @@ export function Icon({ icon, block, ...props }) {
       {icons[icon]}
     </Svg>
   );
-}
+};
 
 Icon.propTypes = {
   icon: PropTypes.string.isRequired,
@@ -46,3 +28,14 @@ Icon.propTypes = {
 Icon.defaultProps = {
   block: false,
 };
+
+const Svg = styled.svg`
+  display: ${(props) => (props.block ? "block" : "inline-block")};
+  vertical-align: middle;
+  shape-rendering: inherit;
+  transform: translate3d(0, 0, 0);
+
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+`;

--- a/src/Icon/Icon.stories.js
+++ b/src/Icon/Icon.stories.js
@@ -36,7 +36,19 @@ const List = styled.ul`
   list-style: none;
 `;
 
-export const Basic = (args) => (
+export const Default = (args) => (
+  <>
+    This is a {args.block ? "block" : "inline"} <Icon {...args} /> icon
+  </>
+);
+
+Default.args = {
+  icon: "smile",
+  "aria-label": "smile",
+  block: false,
+};
+
+export const All = () => (
   <>
     There are {Object.keys(icons).length} icons
     <List>
@@ -50,19 +62,7 @@ export const Basic = (args) => (
   </>
 );
 
-export const Standard = (args) => (
-  <>
-    This is a <Icon {...args} /> icon
-  </>
-);
-
-Standard.args = {
-  icon: "smile",
-  "aria-label": "smile",
-  block: false,
-};
-
-export const Social = (args) => (
+export const Social = () => (
   <>
     There are {Object.keys(iconsSocial).length} social icons
     <List>

--- a/src/Icon/IconSocial.js
+++ b/src/Icon/IconSocial.js
@@ -3,12 +3,7 @@ import React from "react";
 import styled from "styled-components";
 import { iconsSocial } from "../shared/iconsSocial";
 
-const Svg = styled.svg`
-  display: ${(props) => (props.block ? "block" : "inline-block")};
-  vertical-align: middle;
-`;
-
-export function IconSocial({ icon, block, ...props }) {
+export const IconSocial = ({ icon, block, ...props }) => {
   return (
     <Svg
       viewBox="0 0 20 20"
@@ -22,4 +17,9 @@ export function IconSocial({ icon, block, ...props }) {
       {iconsSocial[icon]}
     </Svg>
   );
-}
+};
+
+const Svg = styled.svg`
+  display: ${(props) => (props.block ? "block" : "inline-block")};
+  vertical-align: middle;
+`;

--- a/src/Logo/Logo.js
+++ b/src/Logo/Logo.js
@@ -10,33 +10,7 @@ const THEME = {
   TRANSPARENT: "transparent",
 };
 
-const symbolColors = {
-  dark: color.blue100,
-  blue: color.white,
-  light: color.blue100,
-  transparent: color.blue100,
-};
-
-const wordColors = {
-  dark: color.gray25,
-  blue: color.white,
-  light: color.gray900,
-  transparent: color.gray25,
-};
-
-const Svg = styled.svg`
-  display: block;
-`;
-
-const Symbol = styled.path`
-  fill: ${(props) => symbolColors[props.theme]};
-`;
-
-const Wordmark = styled.path`
-  fill: ${(props) => wordColors[props.theme]};
-`;
-
-export function Logo({ width, height, theme, ...props }) {
+export const Logo = ({ width, height, theme }) => {
   return (
     <Svg
       width={width}
@@ -77,7 +51,7 @@ export function Logo({ width, height, theme, ...props }) {
       />
     </Svg>
   );
-}
+};
 
 Logo.propTypes = {
   theme: PropTypes.oneOf(Object.values(THEME)),
@@ -88,3 +62,29 @@ Logo.defaultProps = {
   width: 1000,
   height: 260,
 };
+
+const symbolColors = {
+  dark: color.blue100,
+  blue: color.white,
+  light: color.blue100,
+  transparent: color.blue100,
+};
+
+const wordColors = {
+  dark: color.gray25,
+  blue: color.white,
+  light: color.gray900,
+  transparent: color.gray25,
+};
+
+const Svg = styled.svg`
+  display: block;
+`;
+
+const Symbol = styled.path`
+  fill: ${(props) => symbolColors[props.theme]};
+`;
+
+const Wordmark = styled.path`
+  fill: ${(props) => wordColors[props.theme]};
+`;

--- a/src/Logo/Logo.stories.js
+++ b/src/Logo/Logo.stories.js
@@ -9,22 +9,22 @@ export default {
   component: Logo,
 };
 
-export const All = (args) => (
-  <>
-    <Background theme="light">
-      <Logo theme="light" />
-    </Background>
-    <Background theme="blue">
-      <Logo theme="blue" />
-    </Background>
-    <Background theme="dark">
-      <Logo theme="dark" />
-    </Background>
-  </>
-);
-
-export const Standard = (args) => (
+export const Default = (args) => (
   <Background {...args}>
     <Logo {...args} />
   </Background>
+);
+
+export const All = () => (
+  <div style={{ display: "flex" }}>
+    <Background theme="light">
+      <Logo theme="light" width="200" />
+    </Background>
+    <Background theme="blue">
+      <Logo theme="blue" width="200" />
+    </Background>
+    <Background theme="dark">
+      <Logo theme="dark" width="200" />
+    </Background>
+  </div>
 );

--- a/src/Navbar/Navbar.js
+++ b/src/Navbar/Navbar.js
@@ -3,12 +3,53 @@ import PropTypes from "prop-types";
 import styled from "styled-components";
 
 import { NavbarItem } from "./NavbarItem";
-
 import { Logo } from "../Logo/Logo";
 import { Icon } from "../Icon/Icon";
 import { Avatar } from "../Avatar/Avatar";
-
 import { color } from "../shared/styles";
+
+const THEME = {
+  DARK: "dark",
+  LIGHT: "light",
+  TRANSPARENT: "transparent",
+};
+
+export const Navbar = ({ ...props }) => {
+  const [current, setCurrent] = useState(null);
+
+  return (
+    <Layout {...props}>
+      <FlexBox>
+        <Logo width="100" height="26" {...props} />
+        <NavbarItemBox>
+          {navData.map(({ name, title }) => {
+            return (
+              <NavbarItem
+                {...props}
+                onClick={() => setCurrent(name)}
+                status={current === name ? "active" : "default"}
+              >
+                {title}
+              </NavbarItem>
+            );
+          })}
+        </NavbarItemBox>
+      </FlexBox>
+      <FlexBox>
+        <Icon icon="bell" stroke={color.gray400} aria-hidden />
+        <Avatar />
+      </FlexBox>
+    </Layout>
+  );
+};
+
+Navbar.propTypes = {
+  theme: PropTypes.oneOf(Object.values(THEME)),
+};
+
+Navbar.defaultProps = {
+  theme: THEME.LIGHT,
+};
 
 const navData = [
   {
@@ -24,12 +65,6 @@ const navData = [
     title: "취업정보",
   },
 ];
-
-const THEME = {
-  DARK: "dark",
-  LIGHT: "light",
-  TRANSPARENT: "transparent",
-};
 
 const bgColor = {
   dark: color.black,
@@ -69,40 +104,3 @@ const NavbarItemBox = styled.div`
   align-items: center;
   margin-left: 3rem;
 `;
-
-export function Navbar({ ...props }) {
-  const [current, setCurrent] = useState(null);
-
-  return (
-    <Layout {...props}>
-      <FlexBox>
-        <Logo width="100" height="26" {...props} />
-        <NavbarItemBox>
-          {navData.map(({ name, title }) => {
-            return (
-              <NavbarItem
-                {...props}
-                onClick={() => setCurrent(name)}
-                status={current === name ? "active" : "default"}
-              >
-                {title}
-              </NavbarItem>
-            );
-          })}
-        </NavbarItemBox>
-      </FlexBox>
-      <FlexBox>
-        <Icon icon="bell" stroke={color.gray400} aria-hidden />
-        <Avatar />
-      </FlexBox>
-    </Layout>
-  );
-}
-
-Navbar.propTypes = {
-  theme: PropTypes.oneOf(Object.values(THEME)),
-};
-
-Navbar.defaultProps = {
-  theme: THEME.LIGHT,
-};

--- a/src/Navbar/Navbar.js
+++ b/src/Navbar/Navbar.js
@@ -43,7 +43,7 @@ const borderColor = {
   transparent: color.gray700,
 };
 
-const StyledNavbar = styled.div`
+const Layout = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -53,35 +53,35 @@ const StyledNavbar = styled.div`
   border-bottom: 1px solid ${(props) => borderColor[props.theme]};
 `;
 
-const StyledNavbarLeft = styled.div`
-  display: flex;
-  align-items: center;
-`;
-
-const StyledNavbarItems = styled.div`
-  display: flex;
-  align-items: center;
-  margin-left: 5rem;
-`;
-
-const StyledNavbarRight = styled.div`
+const FlexBox = styled.div`
   display: flex;
   gap: 2rem;
   align-items: center;
+
+  svg,
+  div {
+    cursor: pointer;
+  }
 `;
 
-export function Navbar({ theme, ...props }) {
+const NavbarItemBox = styled.div`
+  display: flex;
+  align-items: center;
+  margin-left: 3rem;
+`;
+
+export function Navbar({ ...props }) {
   const [current, setCurrent] = useState(null);
 
   return (
-    <StyledNavbar theme={theme} {...props}>
-      <StyledNavbarLeft>
-        <Logo width="100" height="26" theme={theme} />
-        <StyledNavbarItems>
+    <Layout {...props}>
+      <FlexBox>
+        <Logo width="100" height="26" {...props} />
+        <NavbarItemBox>
           {navData.map(({ name, title }) => {
             return (
               <NavbarItem
-                theme={theme}
+                {...props}
                 onClick={() => setCurrent(name)}
                 status={current === name ? "active" : "default"}
               >
@@ -89,20 +89,20 @@ export function Navbar({ theme, ...props }) {
               </NavbarItem>
             );
           })}
-        </StyledNavbarItems>
-      </StyledNavbarLeft>
-      <StyledNavbarRight>
+        </NavbarItemBox>
+      </FlexBox>
+      <FlexBox>
         <Icon icon="bell" stroke={color.gray400} aria-hidden />
         <Avatar />
-      </StyledNavbarRight>
-    </StyledNavbar>
+      </FlexBox>
+    </Layout>
   );
 }
 
-NavbarItem.propTypes = {
+Navbar.propTypes = {
   theme: PropTypes.oneOf(Object.values(THEME)),
 };
 
-NavbarItem.defaultProps = {
+Navbar.defaultProps = {
   theme: THEME.LIGHT,
 };

--- a/src/Navbar/Navbar.stories.js
+++ b/src/Navbar/Navbar.stories.js
@@ -1,0 +1,19 @@
+import React from "react";
+import { Navbar } from "./Navbar";
+
+export default {
+  title: "Design System/Navbar",
+  component: Navbar,
+};
+
+export const Default = (args) => <Navbar {...args} />;
+
+export const All = () => (
+  <>
+    <Navbar theme="light" />
+    <br />
+    <Navbar theme="dark" />
+    <br />
+    <Navbar theme="transparent" />
+  </>
+);

--- a/src/Navbar/NavbarItem.js
+++ b/src/Navbar/NavbarItem.js
@@ -15,6 +15,26 @@ const STATUS = {
   ACTIVE: "active",
 };
 
+export const NavbarItem = ({ children, ...props }) => {
+  return (
+    <Layout {...props}>
+      <Text {...props}>{children}</Text>
+    </Layout>
+  );
+};
+
+NavbarItem.propTypes = {
+  children: PropTypes.node.isRequired,
+  theme: PropTypes.oneOf(Object.values(THEME)),
+  status: PropTypes.oneOf(Object.values(STATUS)),
+};
+
+NavbarItem.defaultProps = {
+  theme: THEME.LIGHT,
+  status: STATUS.DEFAULT,
+  children: "Menu",
+};
+
 const textColor = {
   dark: color.gray25,
   light: color.gray900,
@@ -73,23 +93,3 @@ const Layout = styled.div`
     }
   `}
 `;
-
-export function NavbarItem({ children, ...props }) {
-  return (
-    <Layout {...props}>
-      <Text {...props}>{children}</Text>
-    </Layout>
-  );
-}
-
-NavbarItem.propTypes = {
-  children: PropTypes.node.isRequired,
-  theme: PropTypes.oneOf(Object.values(THEME)),
-  status: PropTypes.oneOf(Object.values(STATUS)),
-};
-
-NavbarItem.defaultProps = {
-  theme: THEME.LIGHT,
-  status: STATUS.DEFAULT,
-  children: "Menu",
-};

--- a/src/Navbar/NavbarItem.js
+++ b/src/Navbar/NavbarItem.js
@@ -51,7 +51,7 @@ const Text = styled.span`
   user-select: none;
 `;
 
-const StyledNavbarItem = styled.div`
+const Layout = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
@@ -76,19 +76,20 @@ const StyledNavbarItem = styled.div`
 
 export function NavbarItem({ children, ...props }) {
   return (
-    <StyledNavbarItem {...props}>
+    <Layout {...props}>
       <Text {...props}>{children}</Text>
-    </StyledNavbarItem>
+    </Layout>
   );
 }
 
 NavbarItem.propTypes = {
-  status: PropTypes.oneOf(Object.values(STATUS)),
-  theme: PropTypes.oneOf(Object.values(THEME)),
   children: PropTypes.node.isRequired,
+  theme: PropTypes.oneOf(Object.values(THEME)),
+  status: PropTypes.oneOf(Object.values(STATUS)),
 };
 
 NavbarItem.defaultProps = {
   theme: THEME.LIGHT,
   status: STATUS.DEFAULT,
+  children: "Menu",
 };

--- a/src/Navbar/NavbarItem.stories.js
+++ b/src/Navbar/NavbarItem.stories.js
@@ -1,14 +1,23 @@
 import React from "react";
 import { NavbarItem } from "./NavbarItem";
-import { Navbar } from "./Navbar";
 import { Background } from "../Background/Background";
 
 export default {
-  title: "Design System/Navbar",
+  title: "Design System/NavbarItem",
   component: NavbarItem,
 };
 
-export const All = (args) => (
+export const Default = (args) => (
+  <Background {...args}>
+    <NavbarItem {...args} />
+  </Background>
+);
+
+Default.args = {
+  children: "Menu",
+};
+
+export const All = () => (
   <>
     <h1>Light theme</h1>
     <hr />
@@ -31,31 +40,5 @@ export const All = (args) => (
         Default
       </NavbarItem>
     </Background>
-  </>
-);
-
-All.storyName = "Item (All)";
-
-export const Standard = (args) => (
-  <Background {...args}>
-    <NavbarItem {...args} />
-  </Background>
-);
-
-Standard.args = {
-  children: "Menu",
-  status: "active",
-  theme: "light",
-};
-
-Standard.storyName = "Item (Standard)";
-
-export const Layout = (args) => (
-  <>
-    <Navbar theme="light" />
-    <br />
-    <Navbar theme="dark" />
-    <br />
-    <Navbar theme="transparent" />
   </>
 );

--- a/src/Toc/Toc.js
+++ b/src/Toc/Toc.js
@@ -15,40 +15,40 @@ const borderColor = {
   light: color.gray200,
 };
 
-const TocWrapper = styled.div`
+const Layout = styled.div`
   display: flex;
   width: 100%;
   border-bottom: 1px solid ${(props) => borderColor[props.theme]};
 `;
 
-export function Toc({ items, theme, ...props }) {
+export function Toc({ items, ...props }) {
   const [current, setCurrent] = useState("info");
 
   return (
-    <TocWrapper theme={theme} {...props}>
+    <Layout {...props}>
       {items.map(({ name, title, number }, index) => {
         return (
           <TocItem
             onClick={() => setCurrent(name)}
             status={current === name ? "active" : "default"}
             number={number}
-            theme={theme}
             key={index}
+            {...props}
           >
             {title}
           </TocItem>
         );
       })}
-    </TocWrapper>
+    </Layout>
   );
 }
 
-TocWrapper.propTypes = {
+Toc.propTypes = {
   items: PropTypes.array.isRequired,
   theme: PropTypes.oneOf(Object.values(THEME)),
 };
 
-TocWrapper.defaultProps = {
+Toc.defaultProps = {
   theme: THEME.LIGHT,
   items: [
     {

--- a/src/Toc/Toc.js
+++ b/src/Toc/Toc.js
@@ -10,18 +10,7 @@ const THEME = {
   LIGHT: "light",
 };
 
-const borderColor = {
-  dark: color.gray700,
-  light: color.gray200,
-};
-
-const Layout = styled.div`
-  display: flex;
-  width: 100%;
-  border-bottom: 1px solid ${(props) => borderColor[props.theme]};
-`;
-
-export function Toc({ items, ...props }) {
+export const Toc = ({ items, ...props }) => {
   const [current, setCurrent] = useState("info");
 
   return (
@@ -41,7 +30,7 @@ export function Toc({ items, ...props }) {
       })}
     </Layout>
   );
-}
+};
 
 Toc.propTypes = {
   items: PropTypes.array.isRequired,
@@ -68,3 +57,14 @@ Toc.defaultProps = {
     },
   ],
 };
+
+const borderColor = {
+  dark: color.gray700,
+  light: color.gray200,
+};
+
+const Layout = styled.div`
+  display: flex;
+  width: 100%;
+  border-bottom: 1px solid ${(props) => borderColor[props.theme]};
+`;

--- a/src/Toc/TocItem.js
+++ b/src/Toc/TocItem.js
@@ -62,7 +62,7 @@ const Number = styled.span`
   font-size: 0.8rem;
 `;
 
-const StyledTocItem = styled.div`
+const Layout = styled.div`
   display: flex;
   justify-content: center;
   align-items: baseline;
@@ -88,12 +88,12 @@ const StyledTocItem = styled.div`
 
 export function TocItem({ children, number, ...props }) {
   return (
-    <StyledTocItem {...props}>
+    <Layout {...props}>
       <Text className="menu" {...props}>
         {children}
       </Text>
       <Number>{number}</Number>
-    </StyledTocItem>
+    </Layout>
   );
 }
 

--- a/src/Toc/TocItem.js
+++ b/src/Toc/TocItem.js
@@ -14,6 +14,30 @@ const STATUS = {
   ACTIVE: "active",
 };
 
+export const TocItem = ({ children, number, ...props }) => {
+  return (
+    <Layout {...props}>
+      <Text className="menu" {...props}>
+        {children}
+      </Text>
+      <Number>{number}</Number>
+    </Layout>
+  );
+};
+
+TocItem.propTypes = {
+  status: PropTypes.oneOf(Object.values(STATUS)),
+  theme: PropTypes.oneOf(Object.values(THEME)),
+  children: PropTypes.node.isRequired,
+};
+
+TocItem.defaultProps = {
+  theme: THEME.LIGHT,
+  status: STATUS.DEFAULT,
+  children: "메뉴",
+  number: "n",
+};
+
 const textColor = {
   dark: {
     active: color.gray25,
@@ -85,27 +109,3 @@ const Layout = styled.div`
     }
   `}
 `;
-
-export function TocItem({ children, number, ...props }) {
-  return (
-    <Layout {...props}>
-      <Text className="menu" {...props}>
-        {children}
-      </Text>
-      <Number>{number}</Number>
-    </Layout>
-  );
-}
-
-TocItem.propTypes = {
-  status: PropTypes.oneOf(Object.values(STATUS)),
-  theme: PropTypes.oneOf(Object.values(THEME)),
-  children: PropTypes.node.isRequired,
-};
-
-TocItem.defaultProps = {
-  theme: THEME.LIGHT,
-  status: STATUS.DEFAULT,
-  children: "메뉴",
-  number: "n",
-};

--- a/src/Toc/TocItem.stories.js
+++ b/src/Toc/TocItem.stories.js
@@ -21,25 +21,23 @@ Default.args = {
   theme: "light",
 };
 
-export const All = (args) => (
+export const All = () => (
   <>
     <h1>Light theme</h1>
     <hr />
     <Background theme="light">
-      <TocItem theme="light" status="active" {...args} />
-      <TocItem theme="light" status="default" {...args} />
+      <TocItem theme="light" status="active" />
+      <TocItem theme="light" status="default" />
     </Background>
     <br />
     <h1>Dark theme</h1>
     <hr />
     <Background theme="dark">
-      <TocItem theme="dark" status="active" {...args} />
-      <TocItem theme="dark" status="default" {...args} />
+      <TocItem theme="dark" status="active" />
+      <TocItem theme="dark" status="default" />
     </Background>
   </>
 );
-
-All.storyName = "All Items";
 
 All.args = {
   children: "메뉴",

--- a/src/Toc/TocNav.js
+++ b/src/Toc/TocNav.js
@@ -10,30 +10,7 @@ const THEME = {
   LIGHT: "light",
 };
 
-const bgColors = {
-  dark: color.black,
-  light: color.white,
-};
-
-const borderColor = {
-  dark: color.gray700,
-  light: color.gray200,
-};
-
-const Layout = styled.div`
-  display: flex;
-  align-items: flex-end;
-
-  width: 100%;
-  height: 60px;
-  // TODO : 레이아웃에 맞게 맞추기
-  padding-left: 468px;
-  border-bottom: 1px solid ${(props) => borderColor[props.theme]};
-
-  background-color: ${(props) => bgColors[props.theme]};
-`;
-
-export function TocNav({ items, ...props }) {
+export const TocNav = ({ items, ...props }) => {
   const [current, setCurrent] = useState("info");
 
   return (
@@ -53,7 +30,7 @@ export function TocNav({ items, ...props }) {
       })}
     </Layout>
   );
-}
+};
 
 TocNav.propTypes = {
   items: PropTypes.array.isRequired,
@@ -80,3 +57,26 @@ TocNav.defaultProps = {
     },
   ],
 };
+
+const bgColors = {
+  dark: color.black,
+  light: color.white,
+};
+
+const borderColor = {
+  dark: color.gray700,
+  light: color.gray200,
+};
+
+const Layout = styled.div`
+  display: flex;
+  align-items: flex-end;
+
+  width: 100%;
+  height: 60px;
+  // TODO : 레이아웃에 맞게 맞추기
+  padding-left: 468px;
+  border-bottom: 1px solid ${(props) => borderColor[props.theme]};
+
+  background-color: ${(props) => bgColors[props.theme]};
+`;

--- a/src/Toc/TocNav.js
+++ b/src/Toc/TocNav.js
@@ -20,7 +20,7 @@ const borderColor = {
   light: color.gray200,
 };
 
-const TocNavWrapper = styled.div`
+const Layout = styled.div`
   display: flex;
   align-items: flex-end;
 
@@ -33,34 +33,34 @@ const TocNavWrapper = styled.div`
   background-color: ${(props) => bgColors[props.theme]};
 `;
 
-export function TocNav({ items, theme, ...props }) {
+export function TocNav({ items, ...props }) {
   const [current, setCurrent] = useState("info");
 
   return (
-    <TocNavWrapper theme={theme} {...props}>
+    <Layout {...props}>
       {items.map(({ name, title, number }, index) => {
         return (
           <TocItem
             onClick={() => setCurrent(name)}
             status={current === name ? "active" : "default"}
             number={number}
-            theme={theme}
             key={index}
+            {...props}
           >
             {title}
           </TocItem>
         );
       })}
-    </TocNavWrapper>
+    </Layout>
   );
 }
 
-TocNavWrapper.propTypes = {
+TocNav.propTypes = {
   items: PropTypes.array.isRequired,
   theme: PropTypes.oneOf(Object.values(THEME)),
 };
 
-TocNavWrapper.defaultProps = {
+TocNav.defaultProps = {
   theme: THEME.LIGHT,
   items: [
     {

--- a/src/Toc/TocNav.stories.js
+++ b/src/Toc/TocNav.stories.js
@@ -1,13 +1,11 @@
 import React from "react";
 
-import { Toc } from "./Toc";
 import { TocNav } from "./TocNav";
-
 import { Background } from "../Background/Background";
 
 export default {
-  title: "Design System/Toc",
-  component: Toc,
+  title: "Design System/TocNavbar",
+  component: TocNav,
 };
 
 const items = [
@@ -28,11 +26,7 @@ const items = [
   },
 ];
 
-export const Default = (args) => (
-  <Background {...args}>
-    <Toc {...args} />
-  </Background>
-);
+export const Default = (args) => <TocNav {...args} />;
 
 Default.args = {
   items,
@@ -40,12 +34,8 @@ Default.args = {
 
 export const All = () => (
   <>
-    <Background theme="light">
-      <Toc theme="light" items={items} />
-    </Background>
+    <TocNav theme="light" items={items} />
     <br />
-    <Background theme="dark">
-      <Toc theme="dark" items={items} />
-    </Background>
+    <TocNav theme="dark" items={items} />
   </>
 );

--- a/src/Toggle/Toggle.js
+++ b/src/Toggle/Toggle.js
@@ -1,18 +1,8 @@
-import React from "react";
+import React, { useState } from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 
 import { color } from "../shared/styles";
-
-const StyledInput = styled.input`
-  display: none;
-  :checked + label {
-    background-color: ${color.blue100};
-    .switch {
-      transform: translateX(20px);
-    }
-  }
-`;
 
 const StyledLabel = styled.label`
   display: block;
@@ -25,6 +15,12 @@ const StyledLabel = styled.label`
 
   cursor: pointer;
   transition: 0.3s;
+`;
+
+const StyledInput = styled.input`
+  :checked + div {
+    transform: translateX(20px);
+  }
 `;
 
 const Switch = styled.div`
@@ -40,16 +36,18 @@ const Switch = styled.div`
   transition: transform 0.2s linear;
 `;
 
-export function Toggle({ isChecked, handleToggle, ...props }) {
+export function Toggle({ ...props }) {
+  const [isChecked, setIsChecked] = useState(false);
+  const handleToggle = () => setIsChecked(!isChecked);
+
   return (
     <>
-      <StyledInput
-        type="checkbox"
-        checked={isChecked}
-        onChange={handleToggle}
-        id="asdf"
-      />
-      <StyledLabel htmlFor="asdf">
+      <StyledLabel checked={isChecked}>
+        <StyledInput
+          type="checkbox"
+          checked={isChecked}
+          onChange={handleToggle}
+        />
         <Switch className="switch" />
       </StyledLabel>
     </>


### PR DESCRIPTION
## 💡 Issue
- closed #41


<br/>

## 🔎 Overview
- **Styled 태그 이름 수정**
  - Wrapper, Styled와 같은 표현으로 태그명이 지나치게 길어짐.
  - 시멘틱하게 수정 (최상위 컴포넌트는 Layout, 내부는 기능 및  CSS 속성 등을 알 수 있도록 명명)
  - [참고](https://github.com/Hi-Fi-Club/FE/wiki/Styled-Components-%3A-Naming-Convention)
     - 단, 모든 요소에 컴포넌트명을 붙이는 것은 불필요한 반복이라고 생각해 필요할 경우만 붙였습니다.

```jsx
// 예시

<Layout theme={theme} {...props}>
  <Textarea
    placeholder="댓글로 의견을 나눠보세요 :)"
    ref={textareaRef}
    onChange={onChange}
    maxLength="500"
    value={comment.value}
    theme={theme}
  />
  <Footer>
    <CharCounter>{comment.count}/500</CharCounter>
    <ButtonBox>
      <Icon icon="smile" aria-hidden />
      <Button
        disabled={!comment.value ? "true" : ""}
        theme={theme}
        {...props}
      >
        등록
      </Button>
    </ButtonBox>
  </Footer>
</Layout>
```

- 함수 선언식 화살표 함수로 변경
- CSS 위치 변경

- **Storybook Controls 옵션 정돈**
  - Default의 경우 control을 모두 열어두고, All의 경우에는 닫아둠 

<br/>

## 📷 Screenshot
![image](https://user-images.githubusercontent.com/87457066/149620638-027c9d7c-205d-4e72-92d5-ccd69f4d65bc.png)
![image](https://user-images.githubusercontent.com/87457066/149620602-810bd13c-e83d-4197-a7b9-6946c89fe1b2.png)


<br/>
